### PR TITLE
Unpin pnpm so onlyBuiltDependencies is honored in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:26 AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN npm install -g pnpm@11.4.0
+RUN npm install -g pnpm
 COPY . /app
 WORKDIR /app
 


### PR DESCRIPTION
PR #392 pinned pnpm to `pnpm@11.4.0` in the Dockerfile. That pinned pnpm does not read the `onlyBuiltDependencies` list from `pnpm-workspace.yaml` during the Docker build, so `pnpm install --frozen-lockfile` reported all three deps (svelte-preprocess, esbuild, core-js-pure) as ignored and failed with `ERR_PNPM_IGNORED_BUILDS`.

This reverts the Dockerfile to floating pnpm (`npm install -g pnpm`), which does read the workspace config. Combined with the now-complete 3-entry `onlyBuiltDependencies` list, the install completes and the build passes.

Only change: one line in `Dockerfile` (`pnpm@11.4.0` -> `pnpm`). `pnpm-workspace.yaml` is unchanged.