### PR TITLE
Add Dependabot cooldown to clear pnpm minimumReleaseAge policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,12 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # Wait before opening PRs so freshly published packages clear the pnpm
+    # `minimumReleaseAge` supply-chain policy (~1 day) enforced in CI. Majors
+    # get a longer cooldown to let the ecosystem settle before we bump.
+    cooldown:
+      default-days: 3
+      semver-major-days: 7
     groups:
       npm_and_yarn:
         patterns:
@@ -12,6 +18,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 3
     groups:
       docker:
         patterns:
@@ -20,6 +28,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 3
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
## Why

CI enforces a pnpm `minimumReleaseAge` supply-chain policy (~1 day). When Dependabot bumps to a package published the same day, `pnpm install --frozen-lockfile` aborts with `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` — exactly what broke #402 (postcss@8.5.19, published that morning).

## What

Adds a [`cooldown`](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown) block so Dependabot waits before opening PRs:

- **npm**: 3 days default, 7 days for majors — clears the ~1-day release-age cutoff with margin, and gives the ecosystem time to settle before major bumps land.
- **docker** / **github-actions**: 3 days, as general hygiene.

Prevents the recurring same-day-publish CI failures without disabling any updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)